### PR TITLE
Containerize the Flask app

### DIFF
--- a/dockerCompose/flask/Dockerfile
+++ b/dockerCompose/flask/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12.4-alpine3.20
+
+# We need curl for the health check - Alpine Package Keeper(APK)
+RUN apk --no-cache add curl
+
+WORKDIR /app
+
+# First, copy dependencies only
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install -r requirements.txt
+
+# Copying the app source separately significantly improves build time by using the cache if no new dependencies are added
+COPY app.py .
+
+CMD ["gunicorn","--bind","0.0.0.0:8080", "app:app"]

--- a/dockerCompose/flask/app.py
+++ b/dockerCompose/flask/app.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask
 
 
@@ -5,6 +6,6 @@ app = Flask(__name__)
 
 @app.route('/about', methods=['GET'])
 def about():
-    version = '0.1.0'
+    version = os.environ.get('APP_VERSION')
 
     return {'version': version}, 200


### PR DESCRIPTION
Added a Docker File to run the flask app in a docker container. Flask App is currently using an env var APP_VERSION to return version from the about endpoint and passing the e flag to the docker run command will do the work.